### PR TITLE
[bugfix]: specify depth in `npm ls` to avoid errors from uninstalled peerDeps

### DIFF
--- a/src/queries/getCompatData.ts
+++ b/src/queries/getCompatData.ts
@@ -16,7 +16,7 @@ export async function getCompatData() {
 async function getDependencies(): Promise<PackageList> {
   const list = await execWithLog(
     'Reading your dependencies',
-    async () => await asyncExec(`npm ls --json`)
+    async () => await asyncExec(`npm ls --depth=0 --json`)
   );
   return JSON.parse(list.stdout).dependencies;
 }


### PR DESCRIPTION
In `npm v8`, the `ls` command will default to `--depth=0`, but to be safe, we'll include it for now.

**Context**:
While attempting to run the CLI in a project that had some dependencies with missing `peerDeps`, it crashed because of `npm` errors relating to them. Using `depth=0` explicitly will avoid this because dependencies (prod, dev, and peer) that are specified in `package.json` will always be included after `npm install`.