### PR TITLE
[chore]: add markdown files and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+    validations:
+      required: false
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: I expected...
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: But what actually happened?
+      placeholder: But I got...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: What lead to this bug?
+      placeholder: But I got...
+      value: |
+        1.
+        2.
+        3.
+        4.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Additional Information
+      description: Anything else that's relevant.
+    validations:
+      required: false
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What package manager are you seeing the problem with?
+      multiple: true
+      options:
+        - npm
+        - yarn
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/ombulabs/depngn/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,0 +1,34 @@
+name: Feature Request
+description: Request a new feature or change to an existing feature
+title: "[Feature Request]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+    validations:
+      required: false
+  - type: textarea
+    id: feature-request
+    attributes:
+      label: Describe your request
+      description: Also, please describe why you'd like to see this change.
+      placeholder: I would like to request...
+    validations:
+      required: true
+  - type: textarea
+    id: possible-implementation
+    attributes:
+      label: Possible Implementation
+      description: If you can, describe how this might be implemented.
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/ombulabs/depngn/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# main (unreleased)
+
+- initial commit
+- [[bugfix]: specify depth in npm ls to avoid errors from uninstalled peerDeps](https://github.com/ombulabs/depngn/pull/1)
+- [[feature]: refactor and disable logging for standalone package](https://github.com/ombulabs/depngn/pull/2)
+- [[feature]: rever logging change](https://github.com/ombulabs/depngn/pull/3)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at oss@ombulabs.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing
+
+## Getting Started
+
+```bash
+git clone git@github.com:ombulabs/depngn.git
+cd depngn
+npm install
+```
+
+To be able to test running the CLI manually:
+
+```bash
+npm run build
+npm link
+depngn --help
+```
+
+## How it works
+
+This package uses several `npm`/`yarn` built-in commands to fetch information about your dependencies:
+
+```bash
+# used when there is no `version` argument passed
+node --version
+
+# gets a list of your top-level dependencies. we use
+# this because it contains the actual version of each
+# package, instead of range (like in `package.json`).
+#
+# `yarn`'s version of this command is weird right now
+# and doesn't respect the `depth` parameter, but the
+# `npm` version works with both for some reason.
+# context: https://github.com/yarnpkg/yarn/issues/3569
+npm ls --depth=0 --json
+
+# this fetches the `package.json` of a dependency and
+# returns the `engines` field, which is used to specify
+# what `node` version it supports, among other things.
+# it isn't a required field, so it's not always present.
+npm view <package-name>@<version> engines --json
+# or
+yarn info <package-name>@<version> engines --json
+```
+
+The project is split into two directories -- `queries`, where the `npm`/`yarn` commands live along with supporting modules. And `cli`, where the functionality of the CLI lives.
+
+## When Submitting a Pull Request:
+
+- If your PR closes any open GitHub issues, please include `Closes #XXXX` in your comment.
+- Please include a summary of the change and which issue is fixed or which feature is introduced.
+- If changes to the behavior are made, clearly describe what are the changes and why.
+- If changes to the UI are made, please include screenshots of the before and after.


### PR DESCRIPTION
This PR adds `CONTRIBUTING.md`, `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, and some Issue templates (using GitHub's new Issues Forms thing).