### PR TITLE
[bugfix]: update shape of data returned from yarn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # main (unreleased)
 
+# 0.1.2
+- [[bugfix]: update shape of data returned from yarn](https://github.com/ombulabs/depngn/pull/5)
+
 # 0.1.1
 
 - [[bugfix]: specify depth in npm ls to avoid errors from uninstalled peerDeps](https://github.com/ombulabs/depngn/pull/1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "depngn",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "depngn",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "arg": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "depngn",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Determine the compatibility of your packages with a given Node version",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/queries/getPackageData.ts
+++ b/src/queries/getPackageData.ts
@@ -14,10 +14,10 @@ function isCompatible(nodeVersion: string, depRange: string) {
 
   const logicalOrRegEx = /||/;
   if (depRange && logicalOrRegEx.test(depRange)) {
-    const rangeArray = depRange.split('||').map((range) => range.trim());
+    const rangeArray = depRange.split('||').map((range) => range.replaceAll(' ', ''));
     compatible = rangeArray.some((range) => satisfies(nodeVersion, range));
   } else {
-    compatible = satisfies(nodeVersion, depRange);
+    compatible = satisfies(nodeVersion, depRange.replaceAll(' ', ''));
   }
   return compatible;
 }


### PR DESCRIPTION
This PR updates the expected shape of the `engines` data coming from `yarn`.

I mistakenly thought it was like `npm`:
```
{
  node: '>=12'
}
```

but it actually looks like this, for some reason:
```
{
  type: 'inspect', 
  data: { 
    node: '>=12' 
  }
}
```

Also, fixed an unrelated issue related to formatting the range strings.