### PR TITLE
[feature]: refactor logs, refactor package manager logic, fix RegEx bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/jest": "^29.1.1",
         "@types/node": "^18.7.19",
         "@types/semver": "^7.3.12",
+        "@types/signal-exit": "^3.0.1",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.1",
         "eslint": "^8.24.0",
@@ -33,6 +34,7 @@
         "prettier": "^2.7.1",
         "rimraf": "^3.0.2",
         "rollup": "^2.79.1",
+        "signal-exit": "^3.0.7",
         "ts-jest": "^29.0.3",
         "typescript": "^4.8.3"
       },
@@ -1492,6 +1494,12 @@
       "version": "7.3.12",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
       "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+      "dev": true
+    },
+    "node_modules/@types/signal-exit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/signal-exit/-/signal-exit-3.0.1.tgz",
+      "integrity": "sha512-OSitN9PP9E/c4tlt1Qdj3CAz5uHD9Da5rhUqlaKyQRCX1T7Zdpbk6YdeZbR2eiE2ce+NMBgVnMxGqpaPSNQDUQ==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -6438,6 +6446,12 @@
       "version": "7.3.12",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
       "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+      "dev": true
+    },
+    "@types/signal-exit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/signal-exit/-/signal-exit-3.0.1.tgz",
+      "integrity": "sha512-OSitN9PP9E/c4tlt1Qdj3CAz5uHD9Da5rhUqlaKyQRCX1T7Zdpbk6YdeZbR2eiE2ce+NMBgVnMxGqpaPSNQDUQ==",
       "dev": true
     },
     "@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/jest": "^29.1.1",
     "@types/node": "^18.7.19",
     "@types/semver": "^7.3.12",
+    "@types/signal-exit": "^3.0.1",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.1",
     "eslint": "^8.24.0",
@@ -60,6 +61,7 @@
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.79.1",
+    "signal-exit": "^3.0.7",
     "ts-jest": "^29.0.3",
     "typescript": "^4.8.3"
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,4 @@
-import { bail } from './log';
+import { execWithLog } from './log';
 import { parseCliArgs } from './parse';
 import { createReport } from './reporter';
 import { createUsage } from './usage';
@@ -12,10 +12,14 @@ export async function cli() {
       createUsage();
     } else {
       validateArgs(version, reporter);
-      const compatData = await depngn(version);
+      const compatData = await execWithLog(
+        'Fetching engine data',
+        async () => await depngn(version)
+      );
       await createReport(compatData, version, reporter);
     }
   } catch (error) {
-    bail(error);
+    console.error(error);
+    process.exitCode = 1;
   }
 }

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -1,5 +1,5 @@
 import arg from 'arg';
-import { asyncExec } from './exec';
+import { asyncExec } from '../queries';
 
 export async function parseCliArgs() {
     const args = arg({

--- a/src/queries/exec.ts
+++ b/src/queries/exec.ts
@@ -1,0 +1,4 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+export const asyncExec = promisify(exec);

--- a/src/queries/getCompatData.ts
+++ b/src/queries/getCompatData.ts
@@ -6,12 +6,12 @@ import { CompatData, EnginesDataArray } from '../types';
 
 export async function getCompatData(version: string) {
   const manager = await getPackageManager();
-  const deps = await getDependencies();
+  const deps = await getDependencies(manager);
   const engines = await getEngines(deps, manager);
   return createCompatData(engines, version);
 }
 
-function createCompatData(compatData: EnginesDataArray, version: string) {
+export function createCompatData(compatData: EnginesDataArray, version: string) {
   const compatObject: Record<string, CompatData> = {};
   compatData.forEach((dep) => {
     compatObject[dep.package] = getPackageData(dep, version);

--- a/src/queries/getDependencies.ts
+++ b/src/queries/getDependencies.ts
@@ -1,10 +1,11 @@
-import { asyncExec, execWithLog } from "../cli/exec";
-import { PackageList } from "../types";
+import { asyncExec } from './exec';
+import { PackageList, Manager } from '../types';
 
-export async function getDependencies(): Promise<PackageList> {
-  const list = await execWithLog(
-    'Reading your dependencies',
-    async () => await asyncExec(`npm ls --depth=0 --json`)
-  );
-  return JSON.parse(list.stdout).dependencies;
+export async function getDependencies(manager: Manager): Promise<PackageList> {
+  try {
+    const list = await asyncExec(manager.list);
+    return JSON.parse(list.stdout).dependencies;
+  } catch (error) {
+    throw error;
+  }
 }

--- a/src/queries/getEngines.ts
+++ b/src/queries/getEngines.ts
@@ -1,38 +1,35 @@
-import { asyncExec, execWithLog } from '../cli/exec';
-import { Managers, viewEnginesCommand } from './getPackageManager';
-import { PackageList } from '../types';
+import { asyncExec } from './exec';
+import { Manager, PackageList } from '../types';
 
-export async function getEngines(deps: PackageList, manager: Managers) {
-  const command = viewEnginesCommand(manager);
-  const depsArray = Object.keys(deps).map(async (dep) => {
-    const engines = await asyncExec(
-      `${command} ${dep}@${deps[dep].version} engines --json`
-    );
-    const range = parseEngines(engines, manager);
-    return {
-      package: dep,
-      range,
-    };
-  });
+export async function getEngines(deps: PackageList, manager: Manager) {
+  try {
+    const depsArray = Object.keys(deps).map(async (dep) => {
+      const engines = await asyncExec(
+        `${manager.engines} ${dep}@${deps[dep].version} engines --json`
+      );
+      const range = parseEngines(engines, manager);
+      return {
+        package: dep,
+        range,
+      };
+    });
 
-  return await execWithLog(
-    'Fetching engine data',
-    async () => await Promise.all(depsArray)
-  );
+    return await Promise.all(depsArray);
+  } catch (error) {
+    throw error;
+  }
 }
 
 function parseEngines(
   engines: { stdout: string; stderr: string },
-  manager: Managers
+  manager: Manager
 ) {
   const res = engines.stdout ? JSON.parse(engines.stdout) : {};
-  switch (manager) {
+  switch (manager.name) {
     case 'npm':
       return res.node ? res.node : '';
-
     case 'yarn':
       return res.data?.node ? res.data.node : '';
-
     default:
       const wrong = manager as never;
       throw new Error(

--- a/src/queries/getEngines.ts
+++ b/src/queries/getEngines.ts
@@ -31,7 +31,7 @@ function parseEngines(
     case 'yarn':
       return res.data?.node ? res.data.node : '';
     default:
-      const wrong = manager as never;
+      const wrong = manager.name as never;
       throw new Error(
         `This error shouldn't happen, but somehow an invalid package manager made it through checks: ${wrong}.`
       );

--- a/src/queries/getPackageData.ts
+++ b/src/queries/getPackageData.ts
@@ -12,7 +12,7 @@ function isCompatible(nodeVersion: string, depRange: string) {
 
   let compatible;
 
-  const logicalOrRegEx = /||/;
+  const logicalOrRegEx = /\|\|/;
   if (depRange && logicalOrRegEx.test(depRange)) {
     const rangeArray = depRange.split('||').map((range) => range.replaceAll(' ', ''));
     compatible = rangeArray.some((range) => satisfies(nodeVersion, range));

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,1 +1,2 @@
 export * from './getCompatData';
+export * from './exec';

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,3 +18,11 @@ export interface PackageData {
 }
 
 export type Reporter = 'terminal' | 'json';
+
+export type ManagerName = 'npm' | 'yarn';
+
+export interface Manager {
+  name: ManagerName;
+  list: string;
+  engines: string;
+}


### PR DESCRIPTION
This PR refactors how logs are handled so that the standalone package does not contain any.

It also:
- adds `signal-exit` so the cursor does not remain hidden if a User exits with `^C` while the loading message is animating
- fixes a bug where the RegEx for `||` was incorrect
- refactors Package Manager logic so we don't need to import functions everywhere (we now pass around a Package Manager object that has all the necessary information)
- moves around some functions/types into files/directories that make more sense to me