### PR TITLE
[feature]: use `process.versions.node`

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,7 +7,7 @@ import { depngn } from '../';
 
 export async function cli() {
   try {
-    const { version, reporter, help } = await parseCliArgs();
+    const { version, reporter, help } = parseCliArgs();
     if (help) {
       createUsage();
     } else {

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -1,26 +1,15 @@
 import arg from 'arg';
-import { asyncExec } from '../queries';
+import { versions } from 'process';
 
-export async function parseCliArgs() {
+export function parseCliArgs() {
     const args = arg({
       '--help': Boolean,
       '--reporter': String,
       '-h': '--help',
       '-r': '--reporter',
     });
-    const version = await safeVersion(args._[0]);
+    const version = args._[0] ?? versions.node;
     const reporter = args['--reporter'] ?? 'terminal';
     const help = args['--help'];
     return { version, reporter, help };
-}
-
-async function safeVersion(version: string): Promise<string> {
-  let output;
-  if (!version) {
-    const res = await asyncExec('node --version');
-    output = res.stdout;
-  } else {
-    output = version;
-  }
-  return output.trim();
 }

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -3,22 +3,18 @@ import { green, red } from 'kleur/colors';
 
 const REPORTERS = ['terminal', 'json'];
 
-export function validateArgs(nodeVersion: string, reporter?: string) {
+export function validateArgs(nodeVersion: string, reporter: string) {
   validateNodeVersion(nodeVersion);
   validateReporter(reporter);
 }
 
 function validateNodeVersion(nodeVersion: string) {
-  // defaults to current Node version if not specified
-  if (!nodeVersion) return true;
   if (!validate(nodeVersion)) {
     throw new Error(`Invalid Node version: ${red(nodeVersion)}.`);
   }
 }
 
-function validateReporter(reporter?: string) {
-  // defaults to 'terminal' if not specified
-  if (!reporter) return true;
+function validateReporter(reporter: string) {
   if (!REPORTERS.includes(reporter)) {
     throw new Error(
       `Invalid reporter: ${red(reporter)}. Valid options are: ${green(


### PR DESCRIPTION
This PR replaces using `exec` to call `node --version` and instead uses `process.versions.node`, to avoid having to wait for an async function.

It also removes some redundant `undefined` checks (in a previous iteration, these values *could* be `undefined`, but now they guaranteed to have a default value after the parsing phase).