### PR TITLE
Support packages that specify * as the node version

### DIFF
--- a/src/queries/getPackageData.ts
+++ b/src/queries/getPackageData.ts
@@ -10,6 +10,9 @@ export function getPackageData(dep: EnginesData, version: string) {
 function isCompatible(nodeVersion: string, depRange: string) {
   if (!depRange) return undefined;
 
+  // if a dependency has `*` for the node version, it's always compatible
+  if (['x', '*'].includes(depRange)) return true;
+
   let compatible;
 
   const logicalOrRegEx = /\|\|/;


### PR DESCRIPTION
This PR fixes #18 

Some packages specify `*` as the node version, which is not handled properly by the `compare-versions` package. So, instead of comparing versions, since `*` means `any version`, it just returns true for isCompatible.

This PR also adds support for the `x` value, which also means `any version`.

You can check that at https://semver.npmjs.com