### PR TITLE
Added html reporting option Closes #11

### DIFF
--- a/src/cli/reporter/html.ts
+++ b/src/cli/reporter/html.ts
@@ -1,0 +1,74 @@
+import { writeFile } from 'fs/promises';
+import { CompatData } from '../../types';
+
+export async function createHtml(compatData: Record<string, CompatData>, version: string, path: string = 'compat.html') {
+  const compatDataKeys = Object.keys(compatData);
+  const classGreen = "green";
+  const classRed = "red";
+  const classYellow = "yellow";
+
+  const style = `
+  h1{
+    font-family: arial, sans-serif;
+  }
+  table {
+    font-family: arial, sans-serif;
+    border-collapse: collapse;
+    width: 100%;
+  }
+  td, th {
+    border: 1px solid #dddddd;
+    text-align: left;
+    padding: 8px;
+  }
+  tr:nth-child(even) {
+    background-color: #dddddd;
+  }
+  .${classRed}{
+    color: #ff0000;
+  }
+  .${classGreen}{
+    color: #0f9b4e;
+  }
+  .${classYellow}{
+    color: #ce8d02;
+  }`
+
+  const tableData = compatDataKeys
+    .map((key) => {
+      const compatible = compatData[key].compatible;
+      const compatibleClass = compatible === undefined ? classYellow : compatible ? classGreen : classRed;
+      return `
+        <tr>
+          <td>${key}</td>
+          <td class="${compatibleClass}">${compatible}</td>
+          <td>${compatData[key].range}</td>
+        </tr>
+        `
+    })
+    .join("");
+
+  const out = `<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <style>
+      ${style}
+    </style>
+    <title>depngn</title>
+  </head>
+  <body>
+    <h1>Node version: ${version}</h1>
+    <table>
+      <tr>
+        <th>package</th>
+        <th>compatible</th>
+        <th>range</th>
+      </tr>
+      ${tableData}
+    </table> 
+  </body>
+  </html>`
+
+  await writeFile(path, out);
+  console.log(`File generated at ${path}`);
+}

--- a/src/cli/reporter/report.ts
+++ b/src/cli/reporter/report.ts
@@ -1,6 +1,7 @@
 import { createJson } from './json';
 import { createTable} from './table';
 import { CompatData } from '../../types';
+import { createHtml } from './html';
 
 export function createReport(
   compatData: Record<string, CompatData>,
@@ -12,6 +13,8 @@ export function createReport(
       return createTable(compatData, version);
     case 'json':
       return createJson(compatData, version);
+    case 'html':
+      return createHtml(compatData, version);
     default:
       const wrong = reporter as never;
       throw new Error(

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -5,7 +5,7 @@ export function createUsage() {
 
   Options:
   -h, --help      output usage information
-  -r, --reporter  which reporter for output. options are: terminal (default), json
+  -r, --reporter  which reporter for output. options are: terminal (default), json, html
 
   Example:
   depngn 12.0.0 --reporter=json

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -1,7 +1,7 @@
 import { validate } from 'compare-versions';
 import { green, red } from 'kleur/colors';
 
-const REPORTERS = ['terminal', 'json'];
+const REPORTERS = ['terminal', 'json', 'html'];
 
 export function validateArgs(nodeVersion: string, reporter: string) {
   validateNodeVersion(nodeVersion);


### PR DESCRIPTION
Added html reporting option
- created createHtml() function for generate html report using with raw html string
- added --reporter=html in cli usage
- added html in validate.ts

Preview of html file
![preview of html reporting option](https://user-images.githubusercontent.com/64678612/209169330-5b7961e9-09d3-4bce-81e9-d7fe64c79bfd.PNG)
