### PR TITLE
[feature]: GitHub links are missing from the npm package page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main (unreleased)
 
+- [[feature]: add links to the GitHub repo to be able to navigate from the npm package page](https://github.com/upgradejs/depngn/pull/27)
 - [[bugfix]: keep README.md, CONTRIBUTING.md and CHANGELOG.md current and up to date](https://github.com/upgradejs/depngn/pull/27)
 - [[feature]: add support for packages that specify * versions](https://github.com/upgradejs/depngn/pull/19)
 - [[feature]: add support for html reporter](https://github.com/upgradejs/depngn/pull/21)
@@ -19,7 +20,7 @@
 # 0.1.1
 - [[bugfix]: specify depth in npm ls to avoid errors from uninstalled peerDeps](https://github.com/ombulabs/depngn/pull/1)
 - [[feature]: refactor and disable logging for standalone package](https://github.com/ombulabs/depngn/pull/2)
-- [[feature]: rever logging change](https://github.com/ombulabs/depngn/pull/3)
+- [[feature]: revert logging change](https://github.com/ombulabs/depngn/pull/3)
 
 # 0.1.0
-- intial commit
+- initial commit

--- a/package.json
+++ b/package.json
@@ -2,6 +2,18 @@
   "name": "depngn",
   "version": "0.1.4",
   "description": "Determine the compatibility of your packages with a given Node version",
+  "author": "Lewis D'Avanzo",
+  "license": "MIT",
+  "bugs": "https://github.com/upgradejs/depngn/issues",
+  "repository": "github:upgradejs/depngn",
+  "keywords": [
+    "engines",
+    "dependencies",
+    "upgrade",
+    "version",
+    "semver",
+    "cli"
+  ],
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -25,19 +37,9 @@
     "test": "jest",
     "test:watch": "jest --watch"
   },
-  "author": "Lewis D'Avanzo",
-  "license": "MIT",
   "engines": {
     "node": ">=10.0.0"
   },
-  "keywords": [
-    "engines",
-    "dependencies",
-    "upgrade",
-    "version",
-    "semver",
-    "cli"
-  ],
   "dependencies": {
     "arg": "^5.0.2",
     "compare-versions": "^5.0.1",


### PR DESCRIPTION
This PR adds the links to the GitHub repo page & issues section to be easily accessible from the npm package page. It also rebases the structure of the `packgage.json` file to contain the general package information closer to the beginning of the file.