### PR TITLE
[bugfix]: support Node versions 10-14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main (unreleased)
 
+-[[bugfix]: support Node versions 10-14](https://github.com/upgradejs/depngn/pull/35)
+
 # 0.3.0
 -[[feature]: add the ability to perform the check in the specified path using --cwd option](https://github.com/upgradejs/depngn/pull/30)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "depngn",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "arg": "^5.0.2",

--- a/src/cli/reporter/html.ts
+++ b/src/cli/reporter/html.ts
@@ -1,4 +1,4 @@
-import { writeFile } from 'fs/promises';
+import { writeFile } from '../../utils';
 import { CompatData } from '../../types';
 
 export async function createHtml(compatData: Record<string, CompatData>, version: string, path: string = 'compat.html') {

--- a/src/cli/reporter/json.ts
+++ b/src/cli/reporter/json.ts
@@ -1,4 +1,4 @@
-import { writeFile } from 'fs/promises';
+import { writeFile } from '../../utils';
 import { CompatData } from '../../types';
 
 export async function createJson(compatData: Record<string, CompatData>, version: string, path: string = 'compat.json') {
@@ -6,6 +6,7 @@ export async function createJson(compatData: Record<string, CompatData>, version
     node: version,
     dependencies: compatData,
   }, null, 2);
+
   await writeFile(path, out);
   console.log(`File generated at ${path}`);
 }

--- a/src/queries/exec.ts
+++ b/src/queries/exec.ts
@@ -1,4 +1,0 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
-
-export const asyncExec = promisify(exec);

--- a/src/queries/getDependencies.ts
+++ b/src/queries/getDependencies.ts
@@ -1,4 +1,4 @@
-import { asyncExec } from './exec';
+import { asyncExec } from '../utils';
 import { PackageList, Manager } from '../types';
 
 export async function getDependencies(manager: Manager): Promise<PackageList> {

--- a/src/queries/getEngines.ts
+++ b/src/queries/getEngines.ts
@@ -1,4 +1,4 @@
-import { asyncExec } from './exec';
+import { asyncExec } from '../utils';
 import { Manager, PackageList, PackageManagerName } from '../types';
 
 export async function getEngines(deps: PackageList, manager: Manager) {

--- a/src/queries/getPackageManager.ts
+++ b/src/queries/getPackageManager.ts
@@ -1,4 +1,4 @@
-import { access } from 'fs/promises';
+import { access } from '../utils';
 import { Manager, PackageManagerName } from '../types';
 
 const PACKAGE_MANAGER: Record<string, Manager> = {

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,2 +1,1 @@
 export * from './getCompatData';
-export * from './exec';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,14 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { writeFile as syncWriteFile, access as syncAccess } from 'fs';
+
+// `fs/promises` is only available from Node v14 onwards
+// so we import the sync versions of `writeFile` and `access` and transform them into 
+// async versions using `promisify` (available from Node v8 onwards)
+// if we ever decided to drop support for Node < v14, we can revert to using `fs/promises`
+//
+// `exec` doesn't have a promise version so we have to promisify it no matter what
+
+export const access = promisify(syncAccess);
+export const asyncExec = promisify(exec);
+export const writeFile = promisify(syncWriteFile);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,7 +5,7 @@ import { writeFile as syncWriteFile, access as syncAccess } from 'fs';
 // `fs/promises` is only available from Node v14 onwards
 // so we import the sync versions of `writeFile` and `access` and transform them into 
 // async versions using `promisify` (available from Node v8 onwards)
-// if we ever decided to drop support for Node < v14, we can revert to using `fs/promises`
+// if we ever decided to drop support for Node <v14, we can revert to using `fs/promises`
 //
 // `exec` doesn't have a promise version so we have to promisify it no matter what
 


### PR DESCRIPTION
This PR fixes a bug where `depngn` would crash on Node versions `<14`. (Resolves #34)

## Context
The `fs/promises` module was added to Node in `v14`. Before that, starting in `v10`, the Promises API was available under `fs.promises` (so, you'd import it like `require('fs').promises`). https://nodejs.org/api/fs.html#promises-api

One solution to this would have been to conditionally import the correct module using dynamic imports:

```ts
const { access } = compare(process.version, '14.0.0', '<')
    ? (await import('fs')).promises
    : await import('fs/promises');
```

But I didn't like the idea of littering the code with conditionals and (potentially) unnecessary async stuff. So, I opted for importing the old sync versions and wrapping them in `promisify` (which has the added benefit of being available starting in Node `v8`, so potentially more "unofficial" support?).

## Changes
- added `utils` directory
- added new "promisified" versions of `access` and `writeFile`
- moved `asyncExec` to `utils` (and removed `src/queries/exec.ts`)

## QA
Unfortunately, I'm now on an M1 Mac which hates letting `nvm` install Node versions `<14` for some reason, so I can't manually test this on my machine (although, I *did* QA with newer Node versions and ran tests and everything works).

To QA you would:
- `nvm use 12` (or any version `>10 && <14`)
- run `depngn`
- it should work now (it should crash without this change).

## Also
Hey everybody! Hope you're all doing well!