### PR TITLE
[bugfix]: removing whitespace from malformed version ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ And it returns a promise that resolves to:
 type DepngnReturn = Record<string, CompatData>;
 
 interface CompatData {
-  compatible: boolean | undefined;
+  compatible: boolean | 'invalid' | undefined;
   range: string;
 }
 ```
@@ -93,6 +93,15 @@ import { depngn } from 'depngn';
 const generateReport = async () => {
   return await depngn({ version: '10.0.0' });
 };
+```
+
+There's also a chance there *is* an `engines` field specified in the package, but the range is invalid in some way. Since RegEx for SemVer can be tricky, we return the folling, if that's the case:
+
+```javascript
+{
+  compatible: 'invalid',
+  range: '1 .2 . 0not-a-valid-range'
+}
 ```
 
 ## Supported Package Managers

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "depngn",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "arg": "^5.0.2",

--- a/src/cli/reporter/html.ts
+++ b/src/cli/reporter/html.ts
@@ -1,11 +1,15 @@
 import { writeFile } from 'fs/promises';
 import { CompatData } from '../../types';
 
-export async function createHtml(compatData: Record<string, CompatData>, version: string, path: string = 'compat.html') {
+export async function createHtml(
+  compatData: Record<string, CompatData>,
+  version: string,
+  path: string = 'compat.html'
+) {
   const compatDataKeys = Object.keys(compatData);
-  const classGreen = "green";
-  const classRed = "red";
-  const classYellow = "yellow";
+  const classGreen = 'green';
+  const classRed = 'red';
+  const classYellow = 'yellow';
 
   const style = `
   h1{
@@ -32,21 +36,26 @@ export async function createHtml(compatData: Record<string, CompatData>, version
   }
   .${classYellow}{
     color: #ce8d02;
-  }`
+  }`;
 
   const tableData = compatDataKeys
     .map((key) => {
       const compatible = compatData[key].compatible;
-      const compatibleClass = compatible === undefined ? classYellow : compatible ? classGreen : classRed;
+      const compatibleClass =
+        compatible === undefined || compatible === 'invalid'
+          ? classYellow
+          : compatible
+          ? classGreen
+          : classRed;
       return `
         <tr>
           <td>${key}</td>
           <td class="${compatibleClass}">${compatible}</td>
           <td>${compatData[key].range}</td>
         </tr>
-        `
+        `;
     })
-    .join("");
+    .join('');
 
   const out = `<!DOCTYPE html>
   <html lang="en">
@@ -67,7 +76,7 @@ export async function createHtml(compatData: Record<string, CompatData>, version
       ${tableData}
     </table> 
   </body>
-  </html>`
+  </html>`;
 
   await writeFile(path, out);
   console.log(`File generated at ${path}`);

--- a/src/cli/reporter/table.ts
+++ b/src/cli/reporter/table.ts
@@ -21,8 +21,8 @@ export function createTable(compatData: Record<string, CompatData>, version: str
   console.log(table(out, config));
 }
 
-function toColorString(value: boolean | undefined) {
-  if (value === undefined) return yellow('undefined');
+function toColorString(value: boolean | string | undefined) {
+  if (value === undefined || value === 'invalid') return yellow(`${value}`);
   const outputColor = value ? green : red;
   return outputColor(value.toString());
 }

--- a/src/queries/getPackageData.ts
+++ b/src/queries/getPackageData.ts
@@ -1,7 +1,7 @@
 import { satisfies } from 'compare-versions';
-import { EnginesData } from '../types';
+import { CompatData, EnginesData } from '../types';
 
-export function getPackageData(dep: EnginesData, version: string) {
+export function getPackageData(dep: EnginesData, version: string): CompatData {
   const range = dep.range ? dep.range : 'n/a';
   const compatible = isCompatible(version, dep.range);
   return { compatible, range };
@@ -13,10 +13,17 @@ function isCompatible(nodeVersion: string, depRange: string) {
   // if a dependency has `*` for the node version, it's always compatible
   if (['x', '*'].includes(depRange)) return true;
 
-  return depRange
+  try {
+    return depRange
     .split('||')
     .map((range) => removeWhitespace(range))
     .some((range) => safeSatisfies(nodeVersion, range));
+  } catch (error) {
+    if ((error as Error).message.match(/Invalid argument not valid semver/)) {
+      return 'invalid';
+    }
+    throw error;
+  }
 }
 
 // accounts for `AND` ranges -- ie, `'>=1.2.9 <2.0.0'`
@@ -30,21 +37,14 @@ function safeSatisfies(nodeVersion: string, range: string) {
   );
 }
 
-// trims leading and trailing whitespace, whitespace
-// between the comparator operators and the actual version number,
-// and whitespace between the numbers/wildcards/decimals in the actual
-// version number. ie, ' > = 1 2. 0 .0 ' becomes '>=12.0.0'
-//
-// it also ensures there's only one space in logical `AND` ranges
-// ie, '>=1.2.9 <2.0.0', because we want to split those later
+// trims leading and trailing whitespace and whitespace
+// between the comparator operators and the actual version number
+// version number. ie, ' > = 12.0.0 ' becomes '>=12.0.0'
 function removeWhitespace(range: string) {
   const comparatorWhitespace = /((?<=(<|>))(\s+)(?=(=)))/g;
   const comparatorAndVersionWhiteSpace = /(?<=(<|>|=|\^|~))(\s+)(?=\d)/g;
-  const remainingRange =
-    /(((\d\s*){1,3})\.\s*(\d\s*){1,3}\.\s*((0\s*)|(\d\s*){1,2})(?!(((<|>)=?)|~|^)?(((\d\s*){1,3})\.)|(\d)))/g;
   return range
     .trim()
     .replace(comparatorWhitespace, '')
-    .replace(comparatorAndVersionWhiteSpace, '')
-    .replace(remainingRange, (match: string) => match.replace(/\s+/g, ''));
+    .replace(comparatorAndVersionWhiteSpace, '');
 }

--- a/src/queries/getPackageData.ts
+++ b/src/queries/getPackageData.ts
@@ -25,9 +25,8 @@ function safeSatisfies(nodeVersion: string, range: string) {
 }
 
 // trims leading and trailing whitespace, whitespace
-// between the comparator operators and the actual version number,
-// whitespace between digits and decimals in the version number, and
-// whitespace between the numbers/wildcards/decimals in the actual
+// between the comparator operators and the actual version number, 
+// and whitespace between the numbers/wildcards/decimals in the actual
 // version number. ie, ' > = 12.0.0 ' becomes '>=12.0.0'
 //
 // it also ensures there's only one space in logical `AND` ranges

--- a/src/queries/getPackageData.ts
+++ b/src/queries/getPackageData.ts
@@ -21,11 +21,17 @@ function isCompatible(nodeVersion: string, depRange: string) {
 
 // accounts for `AND` ranges -- ie, `'>=1.2.9 <2.0.0'`
 function safeSatisfies(nodeVersion: string, range: string) {
-  return range.split(' ').every((r) => satisfies(nodeVersion, r));
+  return (
+    range
+      .split(' ')
+      // filter out any whitespace we may have missed with the RegEx -- ie, `'>=4.2.0    8.0.0'`
+      .filter((r) => !!r)
+      .every((r) => satisfies(nodeVersion, r))
+  );
 }
 
 // trims leading and trailing whitespace, whitespace
-// between the comparator operators and the actual version number, 
+// between the comparator operators and the actual version number,
 // and whitespace between the numbers/wildcards/decimals in the actual
 // version number. ie, ' > = 1 2. 0 .0 ' becomes '>=12.0.0'
 //

--- a/src/queries/getPackageData.ts
+++ b/src/queries/getPackageData.ts
@@ -16,11 +16,12 @@ function isCompatible(nodeVersion: string, depRange: string) {
   let compatible;
 
   const logicalOrRegEx = /\|\|/;
+  const spaceRegEx = /\s/g;
   if (depRange && logicalOrRegEx.test(depRange)) {
-    const rangeArray = depRange.split('||').map((range) => range.replaceAll(' ', ''));
+    const rangeArray = depRange.split('||').map((range) => range.replace(spaceRegEx, ''));
     compatible = rangeArray.some((range) => satisfies(nodeVersion, range));
   } else {
-    compatible = satisfies(nodeVersion, depRange.replaceAll(' ', ''));
+    compatible = satisfies(nodeVersion, depRange.replace(spaceRegEx, ''));
   }
   return compatible;
 }

--- a/src/queries/getPackageData.ts
+++ b/src/queries/getPackageData.ts
@@ -24,7 +24,7 @@ function safeSatisfies(nodeVersion: string, range: string) {
   return (
     range
       .split(' ')
-      // filter out any whitespace we may have missed with the RegEx -- ie, `'>=4.2.0    8.0.0'`
+      // filter out any whitespace we may have missed with the RegEx -- ie, `'>4   <8'`
       .filter((r) => !!r)
       .every((r) => satisfies(nodeVersion, r))
   );
@@ -38,7 +38,13 @@ function safeSatisfies(nodeVersion: string, range: string) {
 // it also ensures there's only one space in logical `AND` ranges
 // ie, '>=1.2.9 <2.0.0', because we want to split those later
 function removeWhitespace(range: string) {
-  const extraSpaceRegEx =
-    /((?<=(<|>))(\s+)(?=(=)))|(?<=(<|>|=|\^|~))(\s+)(?=\d)|((?<=(\d|\.|\*|x|X))(\s+)(?=(\d|\.|\*|x|X)))|(?<=\d)(\s+)(?=\s<|>)/g;
-  return range.trim().replace(extraSpaceRegEx, '');
+  const comparatorWhitespace = /((?<=(<|>))(\s+)(?=(=)))/g;
+  const comparatorAndVersionWhiteSpace = /(?<=(<|>|=|\^|~))(\s+)(?=\d)/g;
+  const remainingRange =
+    /(((\d\s*){1,3})\.\s*(\d\s*){1,3}\.\s*((0\s*)|(\d\s*){1,2})(?!(((<|>)=?)|~|^)?(((\d\s*){1,3})\.)|(\d)))/g;
+  return range
+    .trim()
+    .replace(comparatorWhitespace, '')
+    .replace(comparatorAndVersionWhiteSpace, '')
+    .replace(remainingRange, (match: string) => match.replace(/\s+/g, ''));
 }

--- a/src/queries/getPackageData.ts
+++ b/src/queries/getPackageData.ts
@@ -27,7 +27,7 @@ function safeSatisfies(nodeVersion: string, range: string) {
 // trims leading and trailing whitespace, whitespace
 // between the comparator operators and the actual version number, 
 // and whitespace between the numbers/wildcards/decimals in the actual
-// version number. ie, ' > = 12.0.0 ' becomes '>=12.0.0'
+// version number. ie, ' > = 1 2. 0 .0 ' becomes '>=12.0.0'
 //
 // it also ensures there's only one space in logical `AND` ranges
 // ie, '>=1.2.9 <2.0.0', because we want to split those later

--- a/src/queries/getPackageData.ts
+++ b/src/queries/getPackageData.ts
@@ -13,15 +13,26 @@ function isCompatible(nodeVersion: string, depRange: string) {
   // if a dependency has `*` for the node version, it's always compatible
   if (['x', '*'].includes(depRange)) return true;
 
-  let compatible;
+  return depRange
+    .split('||')
+    .map((range) => removeWhitespace(range))
+    .some((range) => safeSatisfies(nodeVersion, range));
+}
 
-  const logicalOrRegEx = /\|\|/;
-  const spaceRegEx = /\s/g;
-  if (depRange && logicalOrRegEx.test(depRange)) {
-    const rangeArray = depRange.split('||').map((range) => range.replace(spaceRegEx, ''));
-    compatible = rangeArray.some((range) => satisfies(nodeVersion, range));
-  } else {
-    compatible = satisfies(nodeVersion, depRange.replace(spaceRegEx, ''));
-  }
-  return compatible;
+// accounts for `AND` ranges -- ie, `'>=1.2.9 <2.0.0'`
+function safeSatisfies(nodeVersion: string, range: string) {
+  return range.split(' ').every((r) => satisfies(nodeVersion, r));
+}
+
+// trims leading and trailing whitespace and removes whitespace
+// between the comparator operators and the actual version number
+// ie, ' > = 12.0.0 ' becomes '>=12.0.0'
+//
+// does *not* handle whitespace between numbers/decimals 
+// in actual version number (ie, 1 2. 0 .0) -- the RegEx for
+// it would be silly complex, so we handle that in `safeSatisfies`
+// once we know we have a single version
+function removeWhitespace(range: string) {
+  const extraSpaceRegEx = /((?<=(<|>))(\s+)(?=(=)))|(?<=(<|>|=|\^))(\s+)(?=\d)|((?<=(\d|\.))(\s+)(?=(\d|\.)))/g;
+  return range.trim().replace(extraSpaceRegEx, '');
 }

--- a/src/queries/getPackageData.ts
+++ b/src/queries/getPackageData.ts
@@ -30,10 +30,10 @@ function safeSatisfies(nodeVersion: string, range: string) {
 // whitespace between the numbers/wildcards/decimals in the actual
 // version number. ie, ' > = 12.0.0 ' becomes '>=12.0.0'
 //
-// it does *not* remove whitespace between versions in an `AND` range
+// it also ensures there's only one space in logical `AND` ranges
 // ie, '>=1.2.9 <2.0.0', because we want to split those later
 function removeWhitespace(range: string) {
   const extraSpaceRegEx =
-    /((?<=(<|>))(\s+)(?=(=)))|(?<=(<|>|=|\^|~))(\s+)(?=\d)|((?<=(\d|\.|\*|x|X))(\s+)(?=(\d|\.|\*|x|X)))/g;
+    /((?<=(<|>))(\s+)(?=(=)))|(?<=(<|>|=|\^|~))(\s+)(?=\d)|((?<=(\d|\.|\*|x|X))(\s+)(?=(\d|\.|\*|x|X)))|(?<=\d)(\s+)(?=\s<|>)/g;
   return range.trim().replace(extraSpaceRegEx, '');
 }

--- a/src/queries/getPackageData.ts
+++ b/src/queries/getPackageData.ts
@@ -24,15 +24,16 @@ function safeSatisfies(nodeVersion: string, range: string) {
   return range.split(' ').every((r) => satisfies(nodeVersion, r));
 }
 
-// trims leading and trailing whitespace and removes whitespace
-// between the comparator operators and the actual version number
-// ie, ' > = 12.0.0 ' becomes '>=12.0.0'
+// trims leading and trailing whitespace, whitespace
+// between the comparator operators and the actual version number,
+// whitespace between digits and decimals in the version number, and
+// whitespace between the numbers/wildcards/decimals in the actual
+// version number. ie, ' > = 12.0.0 ' becomes '>=12.0.0'
 //
-// does *not* handle whitespace between numbers/decimals 
-// in actual version number (ie, 1 2. 0 .0) -- the RegEx for
-// it would be silly complex, so we handle that in `safeSatisfies`
-// once we know we have a single version
+// it does *not* remove whitespace between versions in an `AND` range
+// ie, '>=1.2.9 <2.0.0', because we want to split those later
 function removeWhitespace(range: string) {
-  const extraSpaceRegEx = /((?<=(<|>))(\s+)(?=(=)))|(?<=(<|>|=|\^))(\s+)(?=\d)|((?<=(\d|\.))(\s+)(?=(\d|\.)))/g;
+  const extraSpaceRegEx =
+    /((?<=(<|>))(\s+)(?=(=)))|(?<=(<|>|=|\^|~))(\s+)(?=\d)|((?<=(\d|\.|\*|x|X))(\s+)(?=(\d|\.|\*|x|X)))/g;
   return range.trim().replace(extraSpaceRegEx, '');
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface EnginesData {
 export type EnginesDataArray = Array<EnginesData>;
 
 export interface CompatData {
-  compatible: boolean | undefined;
+  compatible: boolean | 'invalid' | undefined;
   range: string;
 }
 


### PR DESCRIPTION
Resolves #32 

Wow, this was supposed to be a quick swap out of `replaceAll`, but I realized that it isn't actually that simple (when is it ever? 😅)

# Context
Initially, the `range.replaceAll(' ', '')` call was there to handle malformed version strings (like if there is a space between `>=` and the actual number). However, the comments in [this issue](https://github.com/omichelsen/compare-versions/issues/63) in `compare-versions` made me realize that this isn't actually a good idea.

TL;DR -- whitespace actually has semantic meaning in certain version ranges.

Take the following version range, for example:

```
1.2.7 || >=1.2.9 <2.0.0
```
The whitespace between `>=1.2.9` and `<2.0.0` represents a logical AND. if we stripped that out, it'd be a newly malformed version range. so, following @arielj's suggestion, i went with RegEx.

The RegEx removes whitespace in four situations:
1. Between the characters of the comparator operators (ie, `< =`)
2. Between the operators and the version number (ie, `^ 12`)
3. Between the digits and decimals in the version number (ie, `1 2 .0 . 0`)
4. Between two versions in a logical AND range (ie, `>=4.2.0     <=8.0.0`)

(in the last case, it leaves one space, so each version can be asserted separately)

I believe this is _good enough_ for now (thanks Sandi Metz 😂).

Not to mention, if you read through the above-linked issue in `compare-versions`, the author is currently working on supporting this out-of-the-box, so we can stop worrying about it when the new major version is released.

# My RegEx ~might~ probably does suck

I tested it on regex101.com and it works. but i'm sure it could be optimized somehow. it's long and ugly and has lots of lookaheads/lookbehinds and logical ORs.

Also, it doesn't take into account whitespace in the "extended portions" of a version (ie, `12.0.0-rc.1.canary.beta`) but that probably shouldn't come up for Node versions (I think?).

Another thought is maybe handling malformed version ranges more gracefully (instead of throwing an error). maybe we can have it output something like:
```
 {
  compatible: 'malformed',
  range: '1 2 . 0 . 0'
}
```

I figured that was outside the scope of this PR though. This should fix the issue for now, for the majority of cases (and then it can be `compare-versions`' problem 😂)

# Details

Instead of using if/else logic when there's a `||` present, we treat every range the same:
1. split at `||` (if present)
2. remove whitespace using that obnoxiously long RegEx
3. split the remaining range at `' '` (if present)
4. assert every remaining range with `satisfies`

# QA

To confirm the original bug is gone, just downgrade your Node version to something `v14` or below and run `dev`. It should pass now.

To confirm the RegEx works, I guess you could use an online regex tester for weird edge cases. Or set up a mock project with dependencies that have weird ranges specified. 