### PR TITLE
[bugfix]: filter out `__ngcc_entry_points__.json` file

### DIFF
--- a/src/queries/getDependencies.ts
+++ b/src/queries/getDependencies.ts
@@ -1,10 +1,23 @@
 import { asyncExec } from './exec';
 import { PackageList, Manager } from '../types';
 
+const AUTO_EXCLUDE = [
+  // automatically added to `node_modules` in Angular projects
+  '__ngcc_entry_points__.json',
+];
+
 export async function getDependencies(manager: Manager): Promise<PackageList> {
   try {
     const list = await asyncExec(manager.list);
-    return JSON.parse(list.stdout).dependencies;
+    const parsedList = JSON.parse(list.stdout).dependencies;
+    return Object.keys(parsedList)
+    .filter((dep) => !AUTO_EXCLUDE.includes(dep))
+    .reduce((acc, curr) => {
+      return {
+        ...acc,
+        [curr]: parsedList[curr],
+      }
+    }, {});
   } catch (error) {
     throw error;
   }

--- a/src/queries/getDependencies.ts
+++ b/src/queries/getDependencies.ts
@@ -11,8 +11,10 @@ export async function getDependencies(manager: Manager): Promise<PackageList> {
     const list = await asyncExec(manager.list);
     const parsedList = JSON.parse(list.stdout).dependencies;
     return Object.keys(parsedList)
-    .filter((dep) => !AUTO_EXCLUDE.includes(dep))
     .reduce((acc, curr) => {
+      if (AUTO_EXCLUDE.includes(curr)) {
+        return acc;
+      }
       return {
         ...acc,
         [curr]: parsedList[curr],

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export interface CompatData {
 }
 
 export interface PackageList {
-  [key: string]: PackageData;
+  [depName: string]: PackageData;
 }
 
 export interface PackageData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,9 @@ export interface CompatData {
   range: string;
 }
 
-export type PackageList = Record<string, PackageData>;
+export interface PackageList {
+  [key: string]: PackageData;
+}
 
 export interface PackageData {
   version: string;


### PR DESCRIPTION
This PR fixes a bug where `depngn` was tripping over the `__ngcc_entry_points__.json` file, which is automatically added to `node_modules` in Angular apps when building. Not sure why this ends up being a part of the output of `npm ls` (I don't think it gets added to `package.json` or `package-lock.json`), but ¯\\\_(ツ)_/¯.

Resolves #33.

# Changes
- added an `AUTO_EXCLUDE` array (only has the one entry right now, but I assume other libraries/packages do hacky things to `node_modules` as well, so we can add more stuff there in the future as it comes up)
- filters out auto excluded entries from the initial `npm ls` output
- uses `reduce` to build the new object because we're fancy 💅🏻 (i actually think a `for` loop would be faster here, but this isn't currently the bottleneck of the app -- that's the `npm view` part)

# Future features
This also sort of lays the ground work to give the user the ability to filter out some things, so that's neat! All we'd have to do is add a flag to the CLI args, pass that to the root `depngn` function, and then check the values inside the `filter` in `getDependencies`.