### PR TITLE
[chore]: upgrade `compare-versions` to `6.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "arg": "^5.0.2",
-        "compare-versions": "^5.0.1",
+        "compare-versions": "^6.0.0",
         "fancy-log": "^2.0.0",
         "kleur": "^4.1.5",
         "table": "^6.8.0"
@@ -2770,9 +2770,9 @@
       }
     },
     "node_modules/compare-versions": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
-      "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0.tgz",
+      "integrity": "sha512-s2MzYxfRsE9f/ow8hjn7ysa7pod1xhHdQMsgiJtKx6XSNf4x2N1KG4fjrkUmXcP/e9Y2ZX4zB6sHIso0Lm6evQ=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -8114,9 +8114,9 @@
       "dev": true
     },
     "compare-versions": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
-      "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0.tgz",
+      "integrity": "sha512-s2MzYxfRsE9f/ow8hjn7ysa7pod1xhHdQMsgiJtKx6XSNf4x2N1KG4fjrkUmXcP/e9Y2ZX4zB6sHIso0Lm6evQ=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "arg": "^5.0.2",
-    "compare-versions": "^5.0.1",
+    "compare-versions": "^6.0.0",
     "fancy-log": "^2.0.0",
     "kleur": "^4.1.5",
     "table": "^6.8.0"

--- a/src/core/getPackageData.ts
+++ b/src/core/getPackageData.ts
@@ -14,34 +14,11 @@ function isCompatible(nodeVersion: string, depRange: string) {
   if (['x', '*'].includes(depRange)) return true;
 
   try {
-    return depRange
-      .split('||')
-      .map((range) => removeWhitespace(range))
-      .some((range) => safeSatisfies(nodeVersion, range));
+    return satisfies(nodeVersion, depRange);
   } catch (error) {
     if ((error as Error).message.match(/Invalid argument not valid semver/)) {
       return 'invalid';
     }
     throw error;
   }
-}
-
-// accounts for `AND` ranges -- ie, `'>=1.2.9 <2.0.0'`
-function safeSatisfies(nodeVersion: string, range: string) {
-  return (
-    range
-      .split(' ')
-      // filter out any whitespace we may have missed with the RegEx -- ie, `'>4   <8'`
-      .filter((r) => !!r)
-      .every((r) => satisfies(nodeVersion, r))
-  );
-}
-
-// trims leading and trailing whitespace and whitespace
-// between the comparator operators and the actual version number
-// version number. ie, ' > = 12.0.0 ' becomes '>=12.0.0'
-function removeWhitespace(range: string) {
-  const comparatorWhitespace = /((?<=(<|>))(\s+)(?=(=)))/g;
-  const comparatorAndVersionWhiteSpace = /(?<=(<|>|=|\^|~))(\s+)(?=\d)/g;
-  return range.trim().replace(comparatorWhitespace, '').replace(comparatorAndVersionWhiteSpace, '');
 }

--- a/tests/unit/core/getPackageData/get-package-data.spec.ts
+++ b/tests/unit/core/getPackageData/get-package-data.spec.ts
@@ -23,4 +23,18 @@ describe('getPackageData', () => {
       range: 'not-a-range',
     });
   });
+
+  it('correctly handles malformed range', async () => {
+    const output = getPackageData(
+      {
+        package: 'test-package',
+        range: '> = 8.0.0 < = 9.0.0',
+      },
+      '8.0.0'
+    );
+    expect(output).toStrictEqual({
+      compatible: true,
+      range: '> = 8.0.0 < = 9.0.0',
+    });
+  });
 });


### PR DESCRIPTION
This PR upgrades `compare-versions` to `6.0.0` because this version supports parsing "malformed" version ranges.

It still has the same limitations our solution did -- it will still return `"invalid"` for ranges like `1. 0 . 0` because the RegEx for matching unintentional spaces between numbers (and ignoring _intentional_ spaces) is super complex. i don't think even `npm`'s `semver` package fully supports this -- i believe they just have a bunch of logic to figure out a "best guess".

# CHANGES
- bump `compare-versions` to `6.0.0`
- removed our logic to strip white space between comparator operators
- added a unit test for malformed ranges

# TESTING

You can update the new test at the bottom of `get-package-data.spec.ts` for different variations of unintentional white space. it should support:

- space in the middle of comparator operator characters (`>  =`)
- space between the operators and numbers (`>= 10`)
- extra space between `||` operator and numbers (`8    ||    9`)